### PR TITLE
[CIT-3352] fix race condition

### DIFF
--- a/client_metrics_test.go
+++ b/client_metrics_test.go
@@ -1,0 +1,108 @@
+package grpc_prometheus
+
+import (
+	"context"
+	"testing"
+
+	prom "github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+func TestClientMetricsRaces(t *testing.T) {
+	m := NewClientMetrics()
+	tests := []struct {
+		desc string
+		f    func(t *testing.T)
+	}{
+		{
+			desc: "EnableClientHandlingTimeHistogram",
+			f: func(t *testing.T) {
+				m.EnableClientHandlingTimeHistogram()
+			},
+		},
+		{
+			desc: "EnableClientStreamReceiveTimeHistogram",
+			f: func(t *testing.T) {
+				m.EnableClientStreamReceiveTimeHistogram()
+			},
+		},
+		{
+			desc: "EnableClientStreamSendTimeHistogram",
+			f: func(t *testing.T) {
+				m.EnableClientStreamSendTimeHistogram()
+			},
+		},
+		{
+			desc: "Describe",
+			f: func(t *testing.T) {
+				descriptor := make(chan *prom.Desc)
+				m.Describe(descriptor)
+				go func() {
+					for range descriptor {
+					}
+				}()
+			},
+		},
+		{
+			desc: "Collect",
+			f: func(t *testing.T) {
+				descriptor := make(chan prom.Metric)
+				m.Collect(descriptor)
+				go func() {
+					for range descriptor {
+					}
+				}()
+			},
+		},
+		{
+			desc: "UnaryClientInterceptor",
+			f: func(t *testing.T) {
+				var invoker grpc.UnaryInvoker = func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+					return nil
+				}
+				err := m.UnaryClientInterceptor()(context.Background(), "SomeMethod", 1, 2, nil, invoker)
+				require.NoError(t, err)
+			},
+		},
+		{
+			desc: "StreamClientInterceptor",
+			f: func(t *testing.T) {
+				var invoker grpc.Streamer = func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+					return nil, nil
+				}
+				desc := &grpc.StreamDesc{
+					StreamName: "SomeStream",
+					Handler: func(srv interface{}, stream grpc.ServerStream) error {
+						return nil
+					},
+					ServerStreams: true,
+					ClientStreams: true,
+				}
+				_, err := m.StreamClientInterceptor()(context.Background(), desc, nil, "MethodName", invoker)
+				require.NoError(t, err)
+			},
+		},
+	}
+	wait := make(chan struct{}, len(tests))
+	ch := make(chan struct{})
+	const (
+		goroutines = 50
+		retries    = 50
+	)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			wait <- struct{}{}
+			<-ch
+			for i := 0; i < retries; i++ {
+				for _, test := range tests {
+					test.f(t)
+				}
+			}
+		}()
+	}
+	for i := 0; i < goroutines; i++ {
+		<-wait
+	}
+	close(ch)
+}

--- a/go.sum
+++ b/go.sum
@@ -113,6 +113,7 @@ github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -473,6 +474,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
There is a race in the github.com/90poe/go-grpc-prometheus package, surrounding the DefaultClientMetrics global var.

The problem is that the ClientMetrics type has no locks to secure concurrent access, and DefaultClientMetrics is a shared global var.